### PR TITLE
Ruote Kit removes all registered participants on Chrome

### DIFF
--- a/lib/ruote-kit/resources/participants.rb
+++ b/lib/ruote-kit/resources/participants.rb
@@ -36,7 +36,9 @@ class RuoteKit::Application
       end
     end
 
-    RuoteKit.engine.participant_list = list
+    unless list.empty?
+      RuoteKit.engine.participant_list = list
+    end
 
     respond_to do |format|
 

--- a/lib/ruote-kit/views/participants.html.haml
+++ b/lib/ruote-kit/views/participants.html.haml
@@ -15,15 +15,15 @@
 
   %table.participants
     %thead
-      %td
-        regex
-      %td
-        classname
-      %td
-        options
-      %td
-        &nbsp;
-
+      %tr
+        %td
+          regex
+        %td
+          classname
+        %td
+          options
+        %td
+          &nbsp;
     - @participants.each_with_index do |pa, i|
       %tr
         %td
@@ -44,7 +44,7 @@
 :javascript
 
   function nameInputs () {
-    $('tr').each(function (index) {
+    $('tbody tr').each(function (index) {
       var inputs = $(this).children('td').map(function () {
         return $(this).children('input')[0];
       });

--- a/lib/ruote-kit/views/participants.html.haml
+++ b/lib/ruote-kit/views/participants.html.haml
@@ -24,19 +24,20 @@
           options
         %td
           &nbsp;
-    - @participants.each_with_index do |pa, i|
-      %tr
-        %td
-          %input.participant{ :type => :text, :value => pa.regex }
-        %td
-          %input.participant{ :type => :text, :style => 'width: 350px;', :value => pa.classname }
-        %td
-          %input.participant{ :type => :text, :style => 'width: 350px;', :value => Rufus::Json.encode(pa.options) }
-        %td
-          %a.ruote_button.ruote_minus_button{ :title => 'remove', :href => '', :onclick => 'remove(this); return false;' }
-          %a.ruote_button.ruote_up_button{ :title => 'move up', :href => '', :onclick => 'move(this, "up"); return false;' }
-          %a.ruote_button.ruote_down_button{ :title => 'move down', :href => '', :onclick => 'move(this, "down"); return false;' }
-          %a.ruote_button.ruote_copy_button{ :title => 'copy', :href => '', :onclick => 'copy(this); return false;' }
+    %tbody
+      - @participants.each_with_index do |pa, i|
+        %tr
+          %td
+            %input.participant{ :type => :text, :value => pa.regex }
+          %td
+            %input.participant{ :type => :text, :style => 'width: 350px;', :value => pa.classname }
+          %td
+            %input.participant{ :type => :text, :style => 'width: 350px;', :value => Rufus::Json.encode(pa.options) }
+          %td
+            %a.ruote_button.ruote_minus_button{ :title => 'remove', :href => '', :onclick => 'remove(this); return false;' }
+            %a.ruote_button.ruote_up_button{ :title => 'move up', :href => '', :onclick => 'move(this, "up"); return false;' }
+            %a.ruote_button.ruote_down_button{ :title => 'move down', :href => '', :onclick => 'move(this, "down"); return false;' }
+            %a.ruote_button.ruote_copy_button{ :title => 'copy', :href => '', :onclick => 'copy(this); return false;' }
 
   %input#put_button{ :type => 'submit', :value => 'PUT /_ruote/participants', :onclick => 'nameInputs(); return true;' }
 


### PR DESCRIPTION
Chrome inserts an extra tr around the header elements in the participants table, which makes the javascript function to index the participants fail. The result is that all participants are always removed, even the catchall.
