### PR TITLE
Minor ruote-kit fix to track ruote change

### DIFF
--- a/lib/ruote-kit/helpers/misc_helpers.rb
+++ b/lib/ruote-kit/helpers/misc_helpers.rb
@@ -27,7 +27,7 @@ end
 
       def sample_process_tree
 
-        Rufus::Json.encode(Ruote::Parser.parse(sample_process))
+        Rufus::Json.encode(Ruote::Reader.read(sample_process))
       end
     end
   end

--- a/lib/ruote-kit/views/expression.html.haml
+++ b/lib/ruote-kit/views/expression.html.haml
@@ -41,7 +41,7 @@
         %td
           original tree
         %td
-          - ruby = Ruote::Parser.to_ruby(@expression.original_tree)
+          - ruby = Ruote::Reader.to_ruby(@expression.original_tree)
           - rubyline = ruby.split("\n").first
           - json = Rufus::Json.pretty_encode(@expression.original_tree)
           %pre.pdef{ :onclick => 'Rk.toggleNext(this);' } #{rubyline}
@@ -51,7 +51,7 @@
       %td
         tree
       %td
-        - ruby = Ruote::Parser.to_ruby(@expression.tree)
+        - ruby = Ruote::Reader.to_ruby(@expression.tree)
         - rubyline = ruby.split("\n").first
         - json = Rufus::Json.pretty_encode(@expression.tree)
         %pre.pdef{ :onclick => 'Rk.toggleNext(this);' } #{rubyline}


### PR DESCRIPTION
Hi ruote team.  Thanks again for the great software.

In jmettraux/ruote@627018fbc817a1a9e5ddde46a92b4a7552f98c5b Ruote::Parser became Ruote::Reader.  This is a ruote-kit diff that tracks the ruote change.  Not extensively tested or anything, and I'm not sure it's exhaustive, but it works for me.

Best,
- Chris
  cbuben@eventlogic.com
