### PR TITLE
mozMeasureText broken in FF7

### DIFF
--- a/lib/ruote-kit/public/_ruote/javascripts/ruote-fluo.js
+++ b/lib/ruote-kit/public/_ruote/javascripts/ruote-fluo.js
@@ -890,7 +890,7 @@ var Fluo = function () {
       context.rotate(-Math.PI/2);
     }
 
-    context.mozTextStyle = FluoConstants.FONT;
+    context.mozTextStyle = FluoConstants.FONT; //TODO: Deprecated in FF7 but doesn't harm. I.G.
     context.font = FluoConstants.FONT;
 
     var fs = context.fillStyle;
@@ -1056,14 +1056,18 @@ var Fluo = function () {
       c.write = function (t) {
         this.mozDrawText(t);
       }
-      c.measure = function (t) {
-        return this.mozMeasureText(t);
-      }
     }
     else {
       c.write = function (t) {
         this.fillText(t, 0, 0);
       }
+    }
+    if (this.mozMeasureText) {
+      c.measure = function (t) {
+        return this.mozMeasureText(t);
+      }
+    }
+    else {
       c.measure = function (t) {
         return this.measureText(t).width;
         return t.length * 5;


### PR DESCRIPTION
both mozDrawText and mozMeasureText are deprecated in FF7. It looks like mozDrawText is still defined in FF7 while mozMeasureText is undefined resulting in exception.
