### PR TITLE
fix errors/schedules when GET without any errors/schedules available

### DIFF
--- a/lib/ruote-kit/resources/errors.rb
+++ b/lib/ruote-kit/resources/errors.rb
@@ -28,7 +28,7 @@ class RuoteKit::Application
       respond_with :error
     else
       @count = @errors.size
-      @skip = 0
+      @skip = (@count > 0)? 0 : nil
       @limit = @count
       respond_with :errors
     end

--- a/lib/ruote-kit/resources/schedules.rb
+++ b/lib/ruote-kit/resources/schedules.rb
@@ -18,7 +18,7 @@ class RuoteKit::Application
     @schedules = RuoteKit.engine.schedules(params[:wfid])
 
     @count = @schedules.size
-    @skip = 0
+    @skip = (@count > 0)? 0 : nil
     @limit = @count
 
     respond_with :schedules


### PR DESCRIPTION
When in the follwing screen: 
http://my.domain.com/_ruote/processes/:id

there are 4 GET requests available:  expressions, workitems, errors, schedules.

In case there are no errors or no schedules, clicking those links results in an Internal Sever Error.
This is caused by     @limit = @count    which in case of no results creates @limit = 0.

This in turn causes  view/_pagination.html.haml to get a division by 0 situation on the line:
    - las = ((@count / lim.to_f).ceil - 1) \* lim

Proposed solution sets @skip to nil in case @count = 0 which then skips the pagination section of _pagination.html.haml and will only print 0 errors/schedules.
